### PR TITLE
Remove the hardcoding of the JWT calls + switch to session fetcher fo…

### DIFF
--- a/src/ios/BEMCommunicationHelper.h
+++ b/src/ios/BEMCommunicationHelper.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import "GTMSessionFetcherService.h"
 
 @interface CommunicationHelper : NSObject
 // Wrappers for our specific functionality
@@ -31,4 +32,5 @@
 @property (nonatomic, strong) NSURL* mUrl;
 @property (nonatomic, strong) NSMutableDictionary* mJsonDict;
 @property (nonatomic, strong) void (^mCompletionHandler)(NSData *data, NSURLResponse *response, NSError *error);
+@property (nonatomic, strong) GTMSessionFetcherService* fetcherService;
 @end


### PR DESCRIPTION
…r the remote call

Now that we have fixed the generic JWT auth, we can switch to actually using
it. But after we did that, we found that actual remote call was also not
working although we did use NSURLConnection. Tried switching that to
GTMSessionFetcher as well and it worked!!

It is not using a background session since the input is still a data object and
not a file. Must be something to do with the thread or queue being used, since
I was using the main queue before.
