### PR TITLE
Delete the interface to pushStats from the communication helper

### DIFF
--- a/src/ios/BEMCommunicationHelper.h
+++ b/src/ios/BEMCommunicationHelper.h
@@ -19,7 +19,6 @@
 +(void)getUnclassifiedSections:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler;
 +(void)setClassifiedSections:(NSArray*)sectionDicts completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler;
 +(void)movesCallback:(NSMutableDictionary*)movesParams completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler;
-+(void)setClientStats:(NSDictionary*)statsToSend completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler;
 +(void)phone_to_server:(NSArray*) entriesToPush completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler;;
 
 // Generic GET and POST methods

--- a/src/ios/BEMCommunicationHelper.m
+++ b/src/ios/BEMCommunicationHelper.m
@@ -89,18 +89,6 @@ static inline NSString* NSStringFromBOOL(BOOL aBool) {
     [executor execute];
 }
 
-+(void)setClientStats:(NSMutableDictionary*)statsToSend completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler {
-    NSMutableDictionary *toPush = [[NSMutableDictionary alloc] init];
-    [toPush setObject:statsToSend forKey:@"stats"];
-    
-    NSURL* kBaseURL = [[ConnectionSettings sharedInstance] getConnectUrl];
-    NSURL* kSetStatsURL = [NSURL URLWithString:kSetStatsPath
-                                      relativeToURL:kBaseURL];
-    
-    CommunicationHelper *executor = [[CommunicationHelper alloc] initPost:kSetStatsURL data:toPush completionHandler:completionHandler];
-    [executor execute];
-}
-
 +(void)phone_to_server:(NSArray *)entriesToPush completionHandler:(void (^)(NSData *data, NSURLResponse *response, NSError *error))completionHandler {
     NSMutableDictionary *toPush = [[NSMutableDictionary alloc] init];
     [toPush setObject:entriesToPush forKey:@"phone_to_server"];


### PR DESCRIPTION
This is part of https://github.com/e-mission/cordova-usercache/commit/67ae0c9d8d6fe454d3dfded1a46d95b262f75aac
Note that this is an iOS-only change. The corresponding android change is in `cordova-server-sync` repo.