### PR TITLE
Ensure that all data is sent over as UTF-8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "em-cordova-server-communication",
-  "version": "1.0.1",
-  "description": "Simple package that stores all the connection settings that need to be configured",
+  "version": "1.2.1",
+  "description": "Package that handles communication with the server",
   "cordova": {
     "id": "em-cordova-server-communication",
     "platforms": [

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="edu.berkeley.eecs.emission.cordova.comm"
-        version="1.2.0">
+        version="1.2.1">
 
   <name>ServerComm</name>
   <description>Abstraction for communication settings, and for making both GET

--- a/src/android/CommunicationHelper.java
+++ b/src/android/CommunicationHelper.java
@@ -81,12 +81,13 @@ public class CommunicationHelper {
         String result = "";
         HttpPost msg = new HttpPost(fullURL);
         System.out.println("Posting data to " + msg.getURI());
-        msg.setHeader("Content-Type", "application/json");
+        msg.setHeader("Content-Type", "application/json; charset=UTF-8");
 
         // Fill in the object
         final String userToken = CommunicationHelper.getTokenSync(ctxt);
         filledJsonObject.put("user", userToken);
-        msg.setEntity(new StringEntity(filledJsonObject.toString()));
+        StringEntity se = new StringEntity(filledJsonObject.toString(), "UTF-8");
+        msg.setEntity(se);
 
         // Perform the operation
         AndroidHttpClient connection = AndroidHttpClient.newInstance(ctxt.getString(R.string.app_name));
@@ -121,12 +122,13 @@ public class CommunicationHelper {
             throws IOException, JSONException {
         HttpPost msg = new HttpPost(fullURL);
         System.out.println("Posting data to " + msg.getURI());
-        msg.setHeader("Content-Type", "application/json");
+        msg.setHeader("Content-Type", "application/json; charset=UTF-8");
         JSONObject toPush = new JSONObject();
 
         toPush.put("user", userToken);
         toPush.put(objectLabel, jsonObjectOrArray);
-        msg.setEntity(new StringEntity(toPush.toString()));
+        StringEntity se = new StringEntity(toPush.toString(), "UTF-8");
+        msg.setEntity(se);
         AndroidHttpClient connection = AndroidHttpClient.newInstance(ctxt.getString(R.string.app_name));
         HttpResponse response = connection.execute(msg);
         System.out.println("Got response " + response + " with status " + response.getStatusLine());
@@ -142,12 +144,13 @@ public class CommunicationHelper {
             JSONException, IOException {
         String result = "";
         HttpPost msg = new HttpPost(fullURL);
-        msg.setHeader("Content-Type", "application/json");
+        msg.setHeader("Content-Type", "application/json; charset=UTF-8");
 
         //String result;
         JSONObject toPush = new JSONObject();
         toPush.put("user", userToken);
-        msg.setEntity(new StringEntity(toPush.toString()));
+        StringEntity se = new StringEntity(toPush.toString(), "UTF-8");
+        msg.setEntity(se);
 
         System.out.println("Posting data to "+msg.getURI());
 

--- a/src/ios/BEMCommunicationHelper.m
+++ b/src/ios/BEMCommunicationHelper.m
@@ -155,8 +155,9 @@ static inline NSString* NSStringFromBOOL(BOOL aBool) {
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc]
                                     initWithURL:self.mUrl
                                     cachePolicy:NSURLRequestUseProtocolCachePolicy timeoutInterval:500];
+    // UTF-8 fix from https://stackoverflow.com/questions/28229616/how-to-properly-encode-utf-8-in-ios-using-nsmutableurlrequest
     [request setHTTPMethod:@"POST"];
-    [request setValue:@"application/json"
+    [request setValue:@"application/json; charset=UTF-8"
         forHTTPHeaderField:@"Content-Type"];
     
     NSString *userToken = idToken;


### PR DESCRIPTION
On android, unless we explicitly serialize the data as UTF-8, it is serialized as ISO-8851.
On iOS, it is serialized as UTF-8 by default.

In both, it is probably best to explicitly mark the content as UTF-8 in the HTTP header

Bump up the version number to match

This fixes https://github.com/e-mission/e-mission-docs/issues/333

Testing done:
- on android: set the locale to French, set the date to Fevr and synced data
    - before this change, it did not work
    - after this change, it works
- on iOS, set the locale to French, set the date to Fevr and synced data
    - the formatted data did not have any words so even before this fix, it worked
    - this did not cause a regression