### PR TITLE
:alien: Support rename of JWTAuth to OPCodeAuth

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-em-server-communication",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "description": "Package that handles communication with the server",
   "license": "BSD-3-clause",
   "cordova": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -47,6 +47,14 @@
         <param name="ios-package" value="BEMCommunicationHelperPlugin" />
       </feature>
     </config-file>
+    <podspec>
+      <config>
+        <source url="https://cdn.cocoapods.org/"/>
+      </config>
+      <pods use-frameworks="true">
+        <pod name="GTMSessionFetcher" spec="~> 3.1.0" />
+      </pods>
+    </podspec>
 
     <header-file src="src/ios/BEMCommunicationHelper.h"/>
     <source-file src="src/ios/BEMCommunicationHelper.m"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-server-communication"
-        version="1.2.4">
+        version="1.2.5">
 
   <name>ServerComm</name>
   <description>Abstraction for communication settings, and for making both GET

--- a/src/android/CommunicationHelper.java
+++ b/src/android/CommunicationHelper.java
@@ -20,7 +20,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 import edu.berkeley.eecs.emission.cordova.connectionsettings.ConnectionSettings;
-import edu.berkeley.eecs.emission.cordova.jwtauth.AuthTokenCreationFactory;
+import edu.berkeley.eecs.emission.cordova.opcodeauth.AuthTokenCreationFactory;
 import edu.berkeley.eecs.emission.cordova.unifiedlogger.Log;
 
 import edu.berkeley.eecs.emission.R;


### PR DESCRIPTION
Since we are not supporting generic OpenID/JWT any more Main change:
https://github.com/e-mission/cordova-jwt-auth/pull/46/commits/d95ffffd56ec0c986a6f05e2f1ed1d3a9a25fff1