### PR TITLE
:alien: Use `getOPCode` instead of `getToken`

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
         id="cordova-plugin-em-server-communication"
-        version="1.2.5">
+        version="1.2.6">
 
   <name>ServerComm</name>
   <description>Abstraction for communication settings, and for making both GET

--- a/src/android/CommunicationHelper.java
+++ b/src/android/CommunicationHelper.java
@@ -183,6 +183,6 @@ public class CommunicationHelper {
     }
 
     private static String getTokenSync(Context ctxt) {
-        return AuthTokenCreationFactory.getInstance(ctxt).getServerToken().await().getToken();
+        return AuthTokenCreationFactory.getInstance(ctxt).getOPCode().await().getOPCode();
     }
 }


### PR DESCRIPTION
To be consistent with
https://github.com/e-mission/cordova-jwt-auth/pull/48

This is also part of the workaround for
https://github.com/e-mission/e-mission-docs/issues/930