### PR TITLE
if parsing response as JSON fails, include the raw response in error log

### DIFF
--- a/src/android/CommunicationHelperPlugin.java
+++ b/src/android/CommunicationHelperPlugin.java
@@ -24,11 +24,15 @@ public class CommunicationHelperPlugin extends CordovaPlugin {
                 cordova.getThreadPool().execute(new Runnable() {
                     public void run() {
                         try {
-                String resultString = CommunicationHelper.pushGetJSON(ctxt, fullURL, filledMessage);
-                callbackContext.success(new JSONObject(resultString));
-            } catch (Exception e) {
-                callbackContext.error("While pushing/getting from server "+e.getMessage());
-            }
+                            String resultString = CommunicationHelper.pushGetJSON(ctxt, fullURL, filledMessage);
+                            callbackContext.success(new JSONObject(resultString));
+                        } catch (JSONException e) {
+                            callbackContext.error("While pushing/getting from server, "
+                              + "Response was not JSON: " + resultString
+                              + " Exception: "+e.getMessage());
+                        } catch (Exception e) {
+                            callbackContext.error("While pushing/getting from server, "+e.getMessage());
+                        }
                     }
                 });
             } catch (Exception e) {

--- a/src/ios/BEMCommunicationHelperPlugin.m
+++ b/src/ios/BEMCommunicationHelperPlugin.m
@@ -21,7 +21,10 @@
                                                                 options:kNilOptions
                                                                   error: &parseError];
             if (parseError != NULL) {
-                [self sendError:parseError callBackID:callbackId];
+                NSString *msg = [NSString stringWithFormat: @"Response was not JSON: %@ Error: %@",
+                                [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding],
+                                parseError];
+                [self sendError:msg callBackID:callbackId];
             }
             CDVPluginResult* result = [CDVPluginResult
                                        resultWithStatus:CDVCommandStatus_OK


### PR DESCRIPTION
This was added in order to debug https://github.com/e-mission/e-mission-docs/issues/1080